### PR TITLE
chore: hack to make jest happy

### DIFF
--- a/.changeset/witty-seals-shake.md
+++ b/.changeset/witty-seals-shake.md
@@ -1,0 +1,5 @@
+---
+"alcaeus": patch
+---
+
+`rdf-literal` must be default-imported, otherwise webpack fails to bundle alcaeus

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,6 @@ module.exports = {
     moduleNameMapper: {
         '@rdf-esm/(.*)': '@rdfjs/$1',
         'es6-url-template': 'es6-url-template/url-template.cjs',
+        'rdf-literal': '<rootDir>/tests/helpers/rdfLiteral.cjs',
     },
 }

--- a/src/Resources/CoreMixins/HydraResource.ts
+++ b/src/Resources/CoreMixins/HydraResource.ts
@@ -4,7 +4,7 @@ import type { Constructor, RdfResource, ResourceIdentifier } from '@tpluscode/rd
 import type { Resource, SupportedProperty } from '@rdfine/hydra'
 import TermMap from '@rdf-esm/term-map'
 import { GraphPointer } from 'clownface'
-import { fromRdf } from 'rdf-literal'
+import literal from 'rdf-literal'
 import type { HydraClient } from '../../alcaeus'
 import type { MemberAssertionPattern } from '../Mixins/MemberAssertion'
 import { RuntimeOperation, createMixin } from '../Operation'
@@ -52,7 +52,7 @@ function getObject(this: RdfResource, obj: GraphPointer<ResourceIdentifier | Lit
         })
     }
 
-    return fromRdf(obj.term)
+    return literal.fromRdf(obj.term)
 }
 
 export function createHydraResourceMixin(alcaeus: () => HydraClient<any>) {

--- a/tests/helpers/rdfLiteral.cjs
+++ b/tests/helpers/rdfLiteral.cjs
@@ -1,0 +1,34 @@
+// Mocking rdf-literal out because it causes issues with jest
+const { xsd } = require('@tpluscode/rdf-ns-builders')
+const { fromLiteral } = require('@tpluscode/rdfine/lib/conversion')
+
+module.exports = {
+  fromRdf(obj) {
+    switch (obj.datatype.value) {
+      case xsd.boolean.value:
+        return obj.value === 'true'
+      case xsd.integer.value:
+      case xsd.long.value:
+      case xsd.byte.value:
+      case xsd.short.value:
+      case xsd.int.value:
+      case xsd.negativeInteger.value:
+      case xsd.nonNegativeInteger.value:
+      case xsd.nonPositiveInteger.value:
+      case xsd.positiveInteger.value:
+      case xsd.unsignedByte.value:
+      case xsd.unsignedInt.value:
+      case xsd.unsignedLong.value:
+      case xsd.unsignedShort.value:
+      case xsd.double.value:
+      case xsd.decimal.value:
+      case xsd.float.value:
+        return Number.parseFloat(obj.value)
+      case xsd.date.value:
+      case xsd.dateTime.value:
+        return new Date(Date.parse(obj.value))
+    }
+
+    return obj.value
+  }
+}


### PR DESCRIPTION
I don't understand why, but for some reason both jest and mocha fail to correctly import rdf-literal. 

```diff
-import * as literal from 'rdf-literal'
+import literal from 'rdf-literal'
```

The default import is the correct way. Otherwise this will fail in webpack. 

On the other hand looks like both jest and webpack are wrong as with works with plain node. Unfortunately there is little else that I managed to come up with :/